### PR TITLE
Fix 0709

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -42,9 +42,9 @@ margin-top: 1rem;
   flex: 1;
 }
 .imgbox img {
-  width: 30rem;
-  height: 30rem;
-  max-width: 375px;
+  width: 100vw;
+  height: auto;
+  max-width: 480px;
   object-fit: cover;
 }
 .textbox h2{
@@ -97,9 +97,4 @@ margin-top: 1rem;
   .point__txt {
     margin-left: 8rem;
   }
-}
-@media (max-width:320px){
-  .imgbox img {
-    width: 100vw;
-}
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -29,7 +29,7 @@ margin-top: 1rem;
 .flex {
   display:flex;
   justify-content: center;
-　align-items: center;
+  align-items: center;
   padding: 3rem 0 3rem 0;
   text-align: center;
 }
@@ -75,10 +75,6 @@ margin-top: 1rem;
   color: white;
   flex-wrap: wrap-reverse;
   margin: 0 auto;
-}
-div{
-  align-items: center;
-
 }
 .flex__list{
   justify-content: space-around;


### PR DESCRIPTION

### ① 画像が縮小されて表示されない問題
画像に関しては、widthだけじゃなくて、heightも指定してあげないとちゃんと縮小されないぽい。
メディアクエリの中で、height: autoをつければ、横幅に合わせて高さを自動調節してくれます。
あと、思ったんだけど、やりたいことがiphone5の時に画像がはみ出てしまうのを防ぎたいならば、
max-widthをPC表示時の画像のサイズにしてあげて、スマホとかでみた時は横幅いっぱいで100vwでやってあげればいいのかなとも思ったりしたのだけれど、どうでしょうか？

### ②align-itemsが適用されない問題
に関しては、ただ32行目のalign-itemsの前に、全角スペースが入っているぽい。
全角スペースを可視化するプラグインが、エディターにあると思うから、それをinstallしたら、今後は防げると思うよ！